### PR TITLE
migrate and kill migrate support

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"github.com/CodisLabs/codis/pkg/models"
 	"github.com/juju/errors"
 	log "github.com/ngaut/logging"
-	"github.com/wandoulabs/codis/pkg/models"
 	"hash/crc32"
 	"strconv"
 	"time"

--- a/main.go
+++ b/main.go
@@ -1,24 +1,30 @@
 package main
 
 import (
+	"fmt"
+	//"github.com/CodisLabs/codis/pkg/utils/errors"
+	"github.com/CodisLabs/codis/pkg/utils/log"
+	"github.com/docopt/docopt-go"
+	//log "github.com/ngaut/logging"
 	"strconv"
 	"time"
-	"fmt"
-	"github.com/docopt/docopt-go"
-	log "github.com/ngaut/logging"
 )
 
 type fnHttpCall func(objPtr interface{}, api string, method string, arg interface{}) error
 type codisCheckerFactory func(addr string, defaultTimeout time.Duration) CodisChecker
 
 var args struct {
-	apiServer string
-	logLevel  string
-	quiet     bool
+	apiServer     string
+	zookeeper     string
+	quiet         bool
+	slotNum       int
+	fromGroupId   int
+	targetGroupId int
+	kill          bool
 }
 
 var (
-	version string = "0.1.0"
+	version  string              = "0.2.0"
 	callHttp fnHttpCall          = httpCall
 	acf      codisCheckerFactory = func(addr string, timeout time.Duration) CodisChecker {
 		return &redisChecker{
@@ -44,35 +50,71 @@ func genUrl(args ...interface{}) string {
 	return url
 }
 
+func init() {
+	log.SetLevel(log.LEVEL_INFO)
+}
+
 func main() {
 	usage := `
 Usage:
-	codis-ha sentinel   [--server=S]  [--logLevel=L]
-	codis-ha latency    [--server=S]  [--logLevel=L] [--quiet]
+	codis-ha sentinel    [--server=S]
+	codis-ha latency     [--server=S] [--quiet]
+	codis-ha migrate     [--server=S] [--zookeeper=Z] [--kill] [--num=N] [--from=F] [--target=T]
 	codis-ha version
 
 Options:
-	-s S, --server=S                 Set api server address, default is "localhost:18087".
-	-l L, --logLevel=L               Set loglevel, default is "info".
-	-q, --quiet            		 Set latency output less information without slot latency.	
+	-s S, --server=S             Set api server address, default is "localhost:18087".
+	-q, --quiet            		 Set latency output less information without slot latency.
+	-z Z, --zookeeper=Z          Set zookeeper address, default is "localhost:2181".
+	-k, --kill                   Kill the already running migrate tasks.
+	-n N, --num=N                The number slot want to move, if the specified number bigger than slot number in from group, then move all slot in from group.
+	-f F, --from=F 				 Specify the from group id ,where move the slots from.
+	-t T, --target=T             Specify the target group id ,where move the slots to.
 `
 	d, err := docopt.Parse(usage, nil, true, "", false)
 	if err != nil {
 		log.Errorf("parse arguments failed: %q", err)
 	}
 
-	args.apiServer, _ = d["--server"].(string)
-	args.logLevel, _ = d["--logLevel"].(string)
+	if args.apiServer, _ = d["--server"].(string); args.apiServer == "" {
+		log.Panic("--server parameter needed")
+	}
+
 	args.quiet, _ = d["--quiet"].(bool)
 
-	log.SetLevelByString(args.logLevel)
+	if args.zookeeper, _ = d["--zookeeper"].(string); args.zookeeper == "" {
+		log.Panic("--zookeeper parameter needed")
+	}
+
+	args.kill, _ = d["--kill"].(bool)
+
+	if d["--num"] != nil {
+		args.slotNum, err = strconv.Atoi(d["--num"].(string))
+		if err != nil {
+			log.Panicf("parse --num failed %s", err)
+		}
+	}
+	if d["--from"] != nil {
+		args.fromGroupId, err = strconv.Atoi(d["--from"].(string))
+		if err != nil {
+			log.Panicf("parse --from failed %s", err)
+		}
+	}
+	if d["--target"] != nil {
+		args.targetGroupId, err = strconv.Atoi(d["--target"].(string))
+		if err != nil {
+			log.Panicf("parse --target failed %s", err)
+		}
+	}
 
 	switch {
 	case d["version"].(bool):
-		fmt.Printf("Version %s\n",version)
+		fmt.Printf("Version %s\n", version)
 	case d["sentinel"].(bool):
 		Sentinel()
 	case d["latency"].(bool):
 		new(cmdLatency).Main()
+	case d["migrate"].(bool):
+		new(cmdMigrate).Main()
 	}
 }

--- a/migrate.go
+++ b/migrate.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/CodisLabs/codis/pkg/models"
+	"github.com/CodisLabs/codis/pkg/utils"
+	"github.com/CodisLabs/codis/pkg/utils/log"
+	"github.com/wandoulabs/zkhelper"
+	"time"
+)
+
+type MigrateTaskInfo struct {
+	SlotId     int    `json:"slot_id"`
+	NewGroupId int    `json:"new_group"`
+	Delay      int    `json:"delay"`
+	CreateAt   string `json:"create_at"`
+	Percent    int    `json:"percent"`
+	Status     string `json:"status"`
+	Id         string `json:"-"`
+}
+
+type Tasks []MigrateTaskInfo
+
+type migrateTaskForm struct {
+	From  int `json:"from"`
+	To    int `json:"to"`
+	Group int `json:"new_group"`
+	Delay int `json:"delay"`
+}
+
+type cmdMigrate struct {
+	productName  string
+	safeZkConn   zkhelper.Conn
+	unsafeZkConn zkhelper.Conn
+	fromGroup    models.ServerGroup
+	targetGroup  models.ServerGroup
+}
+
+func (cmd *cmdMigrate) Main() {
+	cmd.initProductName()
+	cmd.initZkConn()
+	if args.kill {
+		log.Info("Kill Migrating slot")
+		cmd.deleteMigrateTasks()
+		cmd.setSlotsOnline()
+		return
+	}
+	cmd.initServerGroup()
+	cmd.verifyBeforeMigrateTasks()
+
+	cmd.migrateSlots(args.slotNum)
+}
+
+func (cmd *cmdMigrate) initProductName() {
+	groups, err := GetServerGroups()
+	if err != nil {
+		log.Panic(err)
+	}
+	for _, g := range groups {
+		cmd.productName = g.ProductName
+		break
+	}
+}
+
+func (cmd *cmdMigrate) verifyBeforeMigrateTasks() {
+	for i := 0; i < 1000; i++ {
+		cmd.checkSlotsOnline()
+		tasks, err := GetMigrateTasks()
+		if err != nil {
+			log.Panic("get migrate status error")
+		}
+		if len(tasks) != 0 {
+			log.Warn("There is running migrate tasks, waiting!!")
+			time.Sleep(time.Second * 10)
+		} else {
+			return
+		}
+		continue
+	}
+	log.Panic("Wait rather long time for already running migrate tasks,quit")
+}
+
+func (cmd *cmdMigrate) checkSlotsOnline() {
+	slots, err := GetSlotList()
+	if err != nil {
+		log.Panicf("Get Slots list err %s", err)
+	}
+	for _, s := range slots {
+		if s.State.Status != "online" {
+			log.Warnf("Slot %d status is %s", s.Id, s.State.Status)
+		}
+	}
+}
+
+func (cmd *cmdMigrate) initZkConn() {
+	zkBuilder := utils.NewConnBuilder(cmd.newZkConn)
+	cmd.safeZkConn = zkBuilder.GetSafeConn()
+	cmd.unsafeZkConn = zkBuilder.GetUnsafeConn()
+}
+
+func (cmd *cmdMigrate) newZkConn() (zkhelper.Conn, error) {
+	return zkhelper.ConnectToZk(args.zookeeper, 30)
+}
+
+func (cmd *cmdMigrate) initServerGroup() {
+	groups, err := GetServerGroups()
+	var fromFind = false
+	var targetFind = false
+	if args.fromGroupId < 0 || args.targetGroupId < 0 {
+		log.Panicf("Both fromGroupId %d and targetGroupId should not small than 0", args.fromGroupId, args.targetGroupId)
+	}
+	if err != nil {
+		log.Panicf("Get servergroup err %s", err)
+	}
+	for _, g := range groups {
+		if args.fromGroupId == g.Id {
+			cmd.productName = g.ProductName
+			cmd.fromGroup = g
+			fromFind = true
+		}
+		if args.targetGroupId == g.Id {
+			cmd.targetGroup = g
+			targetFind = true
+		}
+	}
+	if !fromFind {
+		log.Panicf("from groupId not found %d", args.fromGroupId)
+	}
+	if !targetFind {
+		log.Panicf("target groupId not found %d", args.targetGroupId)
+	}
+}
+
+func (cmd *cmdMigrate) migrateSlots(num int) {
+	if num <= 0 {
+		log.Panicf("slot num%d should bigger than 0 ", num)
+		return
+	}
+	slots, err := GetSlotList()
+	if err != nil {
+		log.Panicf("Get Slots list err %s", err)
+	}
+	count := num
+	for _, s := range slots {
+		cmd.verifyBeforeMigrateTasks()
+		if s.GroupId == cmd.fromGroup.Id {
+			log.Infof("Migrate slot %d from group %d to group %d begin:", s.Id, cmd.fromGroup.Id, cmd.targetGroup.Id)
+			cmd.runSlotMigrate(s.Id, s.Id, cmd.targetGroup.Id, 3)
+			count--
+		}
+		if count <= 0 {
+			log.Infof("Migrate %d slot from group %d to group %d done!", num, cmd.fromGroup.Id, cmd.targetGroup.Id)
+			return
+		}
+	}
+}
+
+func (cmd *cmdMigrate) runSlotMigrate(fromSlotId int, toSlotId int, newGroupId int, delay int) error {
+	migrateInfo := &migrateTaskForm{
+		From:  fromSlotId,
+		To:    toSlotId,
+		Group: newGroupId,
+		Delay: delay,
+	}
+	var v interface{}
+	err := callApi(METHOD_POST, "/api/migrate", migrateInfo, &v)
+	if err != nil {
+		return err
+	}
+	fmt.Println(jsonify(v))
+	return nil
+}
+
+func (cmd *cmdMigrate) tasks() []MigrateTaskInfo {
+	res := Tasks{}
+	tasks, _, _ := cmd.safeZkConn.Children(getMigrateTasksPath(cmd.productName))
+	for _, id := range tasks {
+		data, _, _ := cmd.safeZkConn.Get(getMigrateTasksPath(cmd.productName) + "/" + id)
+		info := new(MigrateTaskInfo)
+		json.Unmarshal(data, info)
+		info.Id = id
+		res = append(res, *info)
+	}
+	return res
+}
+
+func (cmd *cmdMigrate) deleteMigrateTasks() {
+	tasks, _, _ := cmd.safeZkConn.Children(getMigrateTasksPath(cmd.productName))
+	for _, id := range tasks {
+		log.Warnf("Delete Migrate tasks %s", id)
+		cmd.safeZkConn.Delete(getMigrateTasksPath(cmd.productName)+"/"+id, -1)
+	}
+}
+
+func (cmd *cmdMigrate) setSlotsOnline() {
+	slots, err := GetSlotList()
+	if err != nil {
+		log.Panicf("Get Slots list err %s", err)
+	}
+	for _, s := range slots {
+		if s.State.Status != models.SLOT_STATUS_ONLINE {
+			log.Warnf("Before set migrate slot %d from group %d to group %d status %s online.", s.Id, s.State.MigrateStatus.From, s.State.MigrateStatus.To, s.State.Status)
+			zkPath := models.GetSlotPath(s.ProductName, s.Id)
+			s.State.Status = models.SLOT_STATUS_ONLINE
+			s.State.MigrateStatus.From = models.INVALID_ID
+			s.State.MigrateStatus.To = models.INVALID_ID
+			data, err := json.Marshal(s)
+			if err != nil {
+				log.Panic(err)
+			}
+			_, err = zkhelper.CreateOrUpdate(cmd.safeZkConn, zkPath, string(data), 0, zkhelper.DefaultFileACLs(), true)
+			if err != nil {
+				log.Panic(err)
+			}
+			log.Warnf("Set slot %d online done!!", s.Id)
+		}
+	}
+}
+
+func getMigrateTasksPath(product string) string {
+	return fmt.Sprintf("/zk/codis/db_%s/migrate_tasks", product)
+}

--- a/rest.go
+++ b/rest.go
@@ -3,11 +3,68 @@ package main
 import (
 	"bytes"
 	"net/http"
+	"strings"
 
 	"encoding/json"
-	"github.com/juju/errors"
+	//"github.com/CodisLabs/codis/pkg/models"
+	"github.com/CodisLabs/codis/pkg/utils/errors"
+	"github.com/CodisLabs/codis/pkg/utils/log"
+	//"github.com/juju/errors"
 	"io/ioutil"
 )
+
+const (
+	METHOD_GET    HttpMethod = "GET"
+	METHOD_POST   HttpMethod = "POST"
+	METHOD_PUT    HttpMethod = "PUT"
+	METHOD_DELETE HttpMethod = "DELETE"
+)
+
+type HttpMethod string
+
+func jsonify(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}
+
+func callApi(method HttpMethod, apiPath string, params interface{}, retVal interface{}) error {
+	if apiPath[0] != '/' {
+		return errors.Errorf("api path must starts with /")
+	}
+	url := "http://" + args.apiServer + apiPath
+	client := &http.Client{Transport: http.DefaultTransport}
+
+	b, err := json.Marshal(params)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	req, err := http.NewRequest(string(method), url, strings.NewReader(string(b)))
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Errorf("can't connect to dashboard, please check 'dashboard_addr' is corrent in config file")
+		return errors.Trace(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if resp.StatusCode == 200 {
+		err := json.Unmarshal(body, retVal)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	}
+	return errors.Errorf("http status code %d, %s", resp.StatusCode, string(body))
+}
 
 //call http url and get json, then decode to objptr
 func httpCall(objPtr interface{}, url string, method string, arg interface{}) error {

--- a/servergroup.go
+++ b/servergroup.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"github.com/CodisLabs/codis/pkg/models"
 	"github.com/juju/errors"
 	log "github.com/ngaut/logging"
-	"github.com/wandoulabs/codis/pkg/models"
 	"time"
 )
+
+func GetMigrateTasks() (Tasks, error) {
+	var tasks Tasks
+	err := callHttp(&tasks, genUrl(args.apiServer, "/api/migrate/tasks"), "GET", nil)
+	return tasks, err
+}
 
 func GetServerGroups() ([]models.ServerGroup, error) {
 	var groups []models.ServerGroup


### PR DESCRIPTION
Usage:
	codis-ha sentinel    [--server=S]
	codis-ha latency     [--server=S] [--quiet]
	codis-ha migrate     [--server=S] [--zookeeper=Z] [--kill] [--num=N] [--from=F] [--target=T]
	codis-ha version

Options:
	-s S, --server=S             Set api server address, default is "localhost:18087".
	-q, --quiet            		 Set latency output less information without slot latency.
	-z Z, --zookeeper=Z          Set zookeeper address, default is "localhost:2181".
	-k, --kill                   Kill the already running migrate tasks.
	-n N, --num=N                The number slot want to move, if the specified number bigger than slot number in from group, then move all slot in from group.
	-f F, --from=F 				 Specify the from group id ,where move the slots from.
	-t T, --target=T             Specify the target group id ,where move the slots to.